### PR TITLE
Update SHPKeyboardAwareness.podspec

### DIFF
--- a/SHPKeyboardAwareness.podspec
+++ b/SHPKeyboardAwareness.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'Source/SHPKeyboardAwareness.h', 'Source/NSObject+SHPKeyboardAwareness.h', 'Source/SHPKeyboardEvent.h', 'Source/SHPKeyboardAwarenessClient.h'
   s.frameworks = 'UIKit'
-  s.dependency 'ReactiveCocoa', '~> 2.5.0'
+  s.dependency 'ReactiveCocoa', '~> 2.5'
 end


### PR DESCRIPTION
Cocoapods 0.39.0 was not able to resolve '~> 2.5.0', but '~> 2.5' works. It may be because we are specifying our own import of ReactiveCocoa at '~> 2.5'.
