### PR TITLE
Fixes upper case capitalization for class methods

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - SHPKeyboardAwareness (2.4.1)
+  - SHPKeyboardAwareness (3.1.0)
 
 DEPENDENCIES:
   - SHPKeyboardAwareness (from `../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  SHPKeyboardAwareness: 7056dd6d1a23d45d1c174d30f257a8d083bd3a08
+  SHPKeyboardAwareness: 0d7cfe8cac9365a26c720af4a346b1157dc25a16
 
 PODFILE CHECKSUM: dc4919f25d8ac7e1e5b1255cd3ff32c348d7e1f4
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.2.1

--- a/Example/SHPKeyboardAwarenessExample.xcodeproj/project.pbxproj
+++ b/Example/SHPKeyboardAwarenessExample.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/SHPKeyboardAwarenessExample/AdvancedViewController.m
+++ b/Example/SHPKeyboardAwarenessExample/AdvancedViewController.m
@@ -30,7 +30,7 @@
     [self setupSubviews];
     
     // Subscribe to keyboard events. The receiver (self in this case) will be automatically unsubscribed when deallocated
-    self.keyboardAwareness = [SHPKeyboardAwarenessObserver ObserveView:self.containerView observerSuperView:self.view];
+    self.keyboardAwareness = [SHPKeyboardAwarenessObserver observeView:self.containerView observerSuperView:self.view];
     self.keyboardAwareness.delegate = self;
 }
 

--- a/Example/SHPKeyboardAwarenessExample/LongTextViewController.m
+++ b/Example/SHPKeyboardAwarenessExample/LongTextViewController.m
@@ -29,8 +29,8 @@
     
     self.view.backgroundColor = [UIColor whiteColor];
     // Do any additional setup after loading the view.
-    self.keyboardAwareness = [SHPKeyboardAwarenessObserver ObserveView:self.longTextField withDelegate:self observerSuperView:self.view];
-//    self.keyboardAwareness = [SHPKeyboardAwarenessObserver ObserveScrollView:self.scrollView conflictingViewPadding:20];
+    self.keyboardAwareness = [SHPKeyboardAwarenessObserver observeView:self.longTextField withDelegate:self observerSuperView:self.view];
+//    self.keyboardAwareness = [SHPKeyboardAwarenessObserver observeScrollView:self.scrollView conflictingViewPadding:20];
     
     [self setupSubviews];
 }

--- a/Example/SHPKeyboardAwarenessExample/ViewController.m
+++ b/Example/SHPKeyboardAwarenessExample/ViewController.m
@@ -27,10 +27,10 @@
     [self setupSubviews];
     
     // Subscribe to keyboard events. The receiver (self in this case) will be automatically unsubscribed when deallocated
-//    self.keyboardAwareness = [SHPKeyboardAwarenessObserver ObserveWithObserverSuperView:self.view];
+//    self.keyboardAwareness = [SHPKeyboardAwarenessObserver observeWithObserverSuperView:self.view];
 //    self.keyboardAwareness.delegate = self;
     
-    self.keyboardAwareness = [SHPKeyboardAwarenessObserver ObserveView:self.view verticalConstraint:self.bottomConstraint conflictingViewPadding:20];
+    self.keyboardAwareness = [SHPKeyboardAwarenessObserver observeView:self.view verticalConstraint:self.bottomConstraint conflictingViewPadding:20];
 }
 
 - (void)setupSubviews {

--- a/SHPKeyboardAwareness.podspec
+++ b/SHPKeyboardAwareness.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SHPKeyboardAwareness"
-  s.version          = "3.0.0"
+  s.version          = "3.1.0"
   s.summary          = "Handle and avoid the keyboard obstructing your views in a very easy and robust way."
   s.description      = "Get notified when you need to move your text-field / -view.
                         Does not require overriding anything. All you need to do is subscribe to a signal

--- a/Source/SHPEventInfo.m
+++ b/Source/SHPEventInfo.m
@@ -23,7 +23,7 @@
     if( copy ) {
         copy.conflictView = self.conflictView;
         if( self.keyboardInfo) {
-            copy.keyboardInfo = [SHPKeyboardInfo InfoWithEventType:self.keyboardInfo.eventType frame:self.keyboardInfo.rect animationDuration:self.keyboardInfo.animationDuration animationOption:self.keyboardInfo.animationOption];
+            copy.keyboardInfo = [SHPKeyboardInfo infoWithEventType:self.keyboardInfo.eventType frame:self.keyboardInfo.rect animationDuration:self.keyboardInfo.animationDuration animationOption:self.keyboardInfo.animationOption];
         }
         else {
             copy.keyboardInfo = nil;

--- a/Source/SHPKeyboardAwarenessConstraintClient.h
+++ b/Source/SHPKeyboardAwarenessConstraintClient.h
@@ -10,7 +10,7 @@
 
 // Internal client, used for a default implementation of handing keyboardEvents with a Constraint type
 @interface SHPKeyboardAwarenessConstraintClient : NSObject <SHPKeyboardAwarenessClient>
-+ (SHPKeyboardAwarenessConstraintClient *)ClientWithView:(UIView *)view verticalConstraint:(NSLayoutConstraint *)constraint conflictingViewPadding:(CGFloat)padding;
++ (SHPKeyboardAwarenessConstraintClient *)clientWithView:(UIView *)view verticalConstraint:(NSLayoutConstraint *)constraint conflictingViewPadding:(CGFloat)padding;
 
 - (instancetype)initWithView:(UIView *)view verticalConstraint:(NSLayoutConstraint *)constraint conflictingViewPadding:(CGFloat)padding;
 @end

--- a/Source/SHPKeyboardAwarenessConstraintClient.m
+++ b/Source/SHPKeyboardAwarenessConstraintClient.m
@@ -29,7 +29,7 @@
     return self;
 }
 
-+ (SHPKeyboardAwarenessConstraintClient *)ClientWithView:(UIView *)view verticalConstraint:(NSLayoutConstraint *)constraint conflictingViewPadding:(CGFloat)padding {
++ (SHPKeyboardAwarenessConstraintClient *)clientWithView:(UIView *)view verticalConstraint:(NSLayoutConstraint *)constraint conflictingViewPadding:(CGFloat)padding {
     return [[SHPKeyboardAwarenessConstraintClient alloc] initWithView: view verticalConstraint: constraint conflictingViewPadding: padding];
 }
 

--- a/Source/SHPKeyboardAwarenessObserver.h
+++ b/Source/SHPKeyboardAwarenessObserver.h
@@ -38,21 +38,21 @@ typedef NS_ENUM(NSUInteger, SHPKeyboardAwarenessOffsetType){
 /// in the SHPKeyboardAwarenessClient protocol. Does not currently support events for rotation while the keyboard is visible. If required, use
 /// ObserveView:observerSuperView: instead.
 /// @param superView The view that contains the observed views, the Observer will not callback with events that are not childViews of the superView
-+ (instancetype _Nonnull)ObserveWithObserverSuperView: (UIView *_Nullable)superView;
++ (instancetype _Nonnull)observeWithObserverSuperView: (UIView *_Nullable)superView;
 
 /// The receiver will get keyboard events during its life time. The receiver must implement the keyboardTriggeredEvent: method as defined
 /// in the SHPKeyboardAwarenessClient protocol. Does not currently support events for rotation while the keyboard is visible. If required, use
 /// ObserveView:withDelegate:observerSuperView: instead.
 /// @param delegate The delegate to receive keyboardevents
 /// @param superView The view that contains the observed views, the Observer will not callback with events that are not childViews of the superView
-+ (instancetype _Nonnull)ObserveWithDelegate: (id<SHPKeyboardAwarenessClient> _Nullable) delegate observerSuperView: (UIView *_Nullable)superView;
++ (instancetype _Nonnull)observeWithDelegate:(id <SHPKeyboardAwarenessClient> _Nullable)delegate observerSuperView: (UIView *_Nullable)superView;
 
 /// The receiver will get keyboard events during its life time. The receiver must implement the keyboardTriggeredEvent: method as defined
 /// in the SHPKeyboardAwarenessClient protocol. Optionally, provide a view which you want to limit the events to. Keyboard events will be
 /// sent, only when view conflicts with the keyboard bounds.
 /// @param view The view you want to stay clear of the keyboard. Provide nil to get same functionality as ObserveWithObserverSuperView:
 /// @param superView The view that contains the observed views, the Observer will not callback with events that are not childViews of the superView
-+ (instancetype _Nonnull)ObserveView: (UIView *_Nullable)view observerSuperView: (UIView *_Nullable)superView;
++ (instancetype _Nonnull)observeView:(UIView *_Nullable)view observerSuperView: (UIView *_Nullable)superView;
 
 /// The receiver will get keyboard events during its life time. The receiver must implement the keyboardTriggeredEvent: method as defined
 /// in the SHPKeyboardAwarenessClient protocol. Optionally, provide a view which you want to limit the events to. Keyboard events will be
@@ -60,14 +60,14 @@ typedef NS_ENUM(NSUInteger, SHPKeyboardAwarenessOffsetType){
 /// @param view The view you want to stay clear of the keyboard. Provide nil to get same functionality as ObserveWithDelegate:observerSuperView:
 /// @param delegate The delegate to receive keyboardevents
 /// @param superView The view that contains the observed views, the Observer will not callback with events that are not childViews of the superView
-+ (instancetype _Nonnull)ObserveView: (UIView *_Nullable)view withDelegate: (id<SHPKeyboardAwarenessClient> _Nullable) delegate observerSuperView: (UIView *_Nullable)superView;
++ (instancetype _Nonnull)observeView:(UIView *_Nullable)view withDelegate:(id <SHPKeyboardAwarenessClient> _Nullable)delegate observerSuperView: (UIView *_Nullable)superView;
 
 /// Makes the observer observe and handle events for a scrollView. The observer will be the delegate for all events
 /// If you don't wan't to handle the offset your self, then use this method, or, if the view isn't a ScrollView, you might wan't to use the ObserveView:verticalConstraint:conflictingViewPadding:
 /// Note, if you set the delegate after initialisation, you'll have to handle the offset yourself
 /// @param view The scrollView to observe
 /// @param padding The padding will be added around a view that is obscured by the keyboard.
-+ (instancetype _Nonnull)ObserveScrollView: (UIScrollView *_Nonnull)view conflictingViewPadding: (CGFloat)padding;
++ (instancetype _Nonnull)observeScrollView:(UIScrollView *_Nonnull)view conflictingViewPadding: (CGFloat)padding;
 
 /// Makes the observer observe and handle events for a view. The observer will be the delegate for all events
 /// Provide a vertical constraint, which the observer can use to reposition the view
@@ -75,5 +75,5 @@ typedef NS_ENUM(NSUInteger, SHPKeyboardAwarenessOffsetType){
 /// @param view The view to observe
 /// @param constraint Vertical constraint used to move the view
 /// @param padding Padding will be added around the conflicting view
-+ (instancetype _Nonnull)ObserveView: (UIView *_Nonnull)view verticalConstraint: (NSLayoutConstraint *_Nonnull)constraint conflictingViewPadding: (CGFloat)padding;
++ (instancetype _Nonnull)observeView:(UIView *_Nonnull)view verticalConstraint:(NSLayoutConstraint *_Nonnull)constraint conflictingViewPadding: (CGFloat)padding;
 @end

--- a/Source/SHPKeyboardAwarenessObserver.m
+++ b/Source/SHPKeyboardAwarenessObserver.m
@@ -105,31 +105,31 @@ CGRect shp_normalizedFrame(CGRect frame, UIWindow *window) {
 }
 
 #pragma mark - Convenience
-+ (instancetype)ObserveWithObserverSuperView:(UIView *)superView {
++ (instancetype)observeWithObserverSuperView:(UIView *_Nullable)superView {
     return [[SHPKeyboardAwarenessObserver alloc] initWithObserveView:nil delegate:nil observerSuperView:superView];
 }
 
-+ (instancetype)ObserveWithDelegate:(id <SHPKeyboardAwarenessClient> _Nullable)delegate observerSuperView:(UIView * _Nullable)superView {
++ (instancetype)observeWithDelegate:(id <SHPKeyboardAwarenessClient> _Nullable)delegate observerSuperView:(UIView * _Nullable)superView {
     return [[SHPKeyboardAwarenessObserver alloc] initWithObserveView:nil delegate:delegate observerSuperView:superView];
 }
 
-+ (instancetype)ObserveView:(UIView *_Nullable)view observerSuperView:(UIView * _Nullable)superView {
++ (instancetype)observeView:(UIView *_Nullable)view observerSuperView:(UIView * _Nullable)superView {
     return [[SHPKeyboardAwarenessObserver alloc] initWithObserveView:view delegate:nil observerSuperView:superView];
 }
 
-+ (instancetype)ObserveView:(UIView *_Nullable)view withDelegate:(id <SHPKeyboardAwarenessClient> _Nullable)delegate observerSuperView:(UIView * _Nullable)superView {
++ (instancetype)observeView:(UIView *_Nullable)view withDelegate:(id <SHPKeyboardAwarenessClient> _Nullable)delegate observerSuperView:(UIView * _Nullable)superView {
     return [[SHPKeyboardAwarenessObserver alloc] initWithObserveView:view delegate:delegate observerSuperView:superView];
 }
 
-+ (instancetype _Nonnull)ObserveScrollView: (UIScrollView *_Nonnull)view conflictingViewPadding: (CGFloat)padding {
-    SHPKeyboardAwarenessScrollViewClient *observerClient = [SHPKeyboardAwarenessScrollViewClient ClientWithView: view conflictingViewPadding: padding];
++ (instancetype _Nonnull)observeScrollView:(UIScrollView *_Nonnull)view conflictingViewPadding: (CGFloat)padding {
+    SHPKeyboardAwarenessScrollViewClient *observerClient = [SHPKeyboardAwarenessScrollViewClient clientWithView:view conflictingViewPadding:padding];
     SHPKeyboardAwarenessObserver *observer = [[SHPKeyboardAwarenessObserver alloc] initWithObserveView:nil delegate:observerClient observerSuperView:view];
     observer.client = observerClient;
     return observer;
 }
 
-+ (instancetype _Nonnull)ObserveView: (UIView *_Nonnull)view verticalConstraint: (NSLayoutConstraint *_Nonnull)constraint conflictingViewPadding: (CGFloat)padding {
-    SHPKeyboardAwarenessConstraintClient *observerClient = [SHPKeyboardAwarenessConstraintClient ClientWithView: view verticalConstraint: constraint conflictingViewPadding: padding];
++ (instancetype _Nonnull)observeView:(UIView *_Nonnull)view verticalConstraint:(NSLayoutConstraint *_Nonnull)constraint conflictingViewPadding: (CGFloat)padding {
+    SHPKeyboardAwarenessConstraintClient *observerClient = [SHPKeyboardAwarenessConstraintClient clientWithView:view verticalConstraint:constraint conflictingViewPadding:padding];
     SHPKeyboardAwarenessObserver *observer = [[SHPKeyboardAwarenessObserver alloc] initWithObserveView:nil delegate:observerClient observerSuperView:view];
     observer.client = observerClient;
     return observer;
@@ -217,12 +217,12 @@ CGRect shp_normalizedFrame(CGRect frame, UIWindow *window) {
 
     if( [notification.name isEqualToString:UIKeyboardWillShowNotification] ) {
         SHPEventInfo *eventInfoCopy = [self.eventInfo copy];
-        eventInfoCopy.keyboardInfo = [SHPKeyboardInfo InfoWithEventType: SHPKeyboardEventTypeShow frame: keyboardFrame animationDuration: animationDuration animationOption: animationCurve];
+        eventInfoCopy.keyboardInfo = [SHPKeyboardInfo infoWithEventType:SHPKeyboardEventTypeShow frame:keyboardFrame animationDuration:animationDuration animationOption:animationCurve];
         self.eventInfo = eventInfoCopy;
     }
     else if( [notification.name isEqualToString:UIKeyboardWillHideNotification] ) {
         SHPEventInfo *eventInfoCopy = [self.eventInfo copy];
-        eventInfoCopy.keyboardInfo = [SHPKeyboardInfo InfoWithEventType: SHPKeyboardEventTypeHide frame: CGRectZero animationDuration: animationDuration animationOption: animationCurve];
+        eventInfoCopy.keyboardInfo = [SHPKeyboardInfo infoWithEventType:SHPKeyboardEventTypeHide frame:CGRectZero animationDuration:animationDuration animationOption:animationCurve];
         self.eventInfo = eventInfoCopy;
     }
 }

--- a/Source/SHPKeyboardAwarenessScrollViewClient.h
+++ b/Source/SHPKeyboardAwarenessScrollViewClient.h
@@ -12,5 +12,5 @@
 @interface SHPKeyboardAwarenessScrollViewClient : NSObject <SHPKeyboardAwarenessClient>
 - (instancetype _Nonnull)initWithView:(UIScrollView *_Nonnull)view conflictingViewPadding:(CGFloat)padding;
 
-+ (instancetype _Nonnull)ClientWithView:(UIScrollView *_Nonnull)view conflictingViewPadding:(CGFloat)padding;
++ (instancetype _Nonnull)clientWithView:(UIScrollView *_Nonnull)view conflictingViewPadding:(CGFloat)padding;
 @end

--- a/Source/SHPKeyboardAwarenessScrollViewClient.m
+++ b/Source/SHPKeyboardAwarenessScrollViewClient.m
@@ -27,7 +27,7 @@
     return self;
 }
 
-+ (instancetype _Nonnull)ClientWithView:(UIScrollView *_Nonnull)view conflictingViewPadding:(CGFloat)padding {
++ (instancetype _Nonnull)clientWithView:(UIScrollView *_Nonnull)view conflictingViewPadding:(CGFloat)padding {
     return [[SHPKeyboardAwarenessScrollViewClient alloc] initWithView: view conflictingViewPadding: padding];
 }
 

--- a/Source/SHPKeyboardInfo.h
+++ b/Source/SHPKeyboardInfo.h
@@ -12,7 +12,7 @@
 @property(nonatomic, readonly) NSTimeInterval animationDuration;
 @property(nonatomic, readonly) UIViewAnimationCurve animationOption;
 
-+ (SHPKeyboardInfo *)InfoWithEventType:(SHPKeyboardEventType)eventType frame:(CGRect)keyboardRect animationDuration:(NSTimeInterval)animationDuration animationOption:(UIViewAnimationCurve)animationOption;
++ (SHPKeyboardInfo *)infoWithEventType:(SHPKeyboardEventType)eventType frame:(CGRect)keyboardRect animationDuration:(NSTimeInterval)animationDuration animationOption:(UIViewAnimationCurve)animationOption;
 - (instancetype)initWithEventType:(SHPKeyboardEventType)eventType frame:(CGRect)keyboardRect animationDuration:(NSTimeInterval)animationDuration animationOption:(UIViewAnimationCurve)animationOption;
 
 @end

--- a/Source/SHPKeyboardInfo.m
+++ b/Source/SHPKeyboardInfo.m
@@ -16,7 +16,7 @@
 @implementation SHPKeyboardInfo {
 
 }
-+ (SHPKeyboardInfo *)InfoWithEventType:(SHPKeyboardEventType)eventType frame:(CGRect)keyboardRect animationDuration:(NSTimeInterval)animationDuration animationOption:(UIViewAnimationCurve)animationOption {
++ (SHPKeyboardInfo *)infoWithEventType:(SHPKeyboardEventType)eventType frame:(CGRect)keyboardRect animationDuration:(NSTimeInterval)animationDuration animationOption:(UIViewAnimationCurve)animationOption {
     return [[SHPKeyboardInfo alloc] initWithEventType: eventType frame: keyboardRect animationDuration: animationDuration animationOption: animationOption];
 }
 


### PR DESCRIPTION
All class methods were capitalised, this clashes with Apple's naming conventions: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html