### PR TITLE
Correction where view changed set as the event, instead of show

### DIFF
--- a/Source/SHPKeyboardAwarenessObserver.m
+++ b/Source/SHPKeyboardAwarenessObserver.m
@@ -230,7 +230,7 @@ CGRect shp_normalizedFrame(CGRect frame, UIWindow *window) {
 #pragma mark - Event handling
 - (void)setEventInfo:(SHPEventInfo *)eventInfo {
     SHPKeyboardEvent *keyboardEvent;
-    if( eventInfo.conflictView != nil && eventInfo.keyboardInfo != nil && _eventInfo.keyboardInfo != nil) {
+    if( eventInfo.conflictView != nil && eventInfo.keyboardInfo != nil && _eventInfo.keyboardInfo != nil && _eventInfo.conflictView) {
         // Change view/keyboard or hide keyboard
         // this is at least a second time we are called
 
@@ -253,7 +253,7 @@ CGRect shp_normalizedFrame(CGRect frame, UIWindow *window) {
         }
 
     }
-    else if( eventInfo.conflictView != nil && eventInfo.keyboardInfo != nil && eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow) {
+    else if( eventInfo.conflictView != nil && eventInfo.keyboardInfo != nil && (eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow || _eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow)) {
         // Show keyboard
         keyboardEvent = [self showEventWithKeyboardInfo:eventInfo.keyboardInfo conflictingView:eventInfo.conflictView];
     }


### PR DESCRIPTION
If the keyboard is presented before the view is set, the event will be returned as "ViewChanged", this seems wrong since it'll be the first view that is in conflict when the keyboard shows.

Instead, the ViewChanged should only be set as an event, if the the view being edited changes - and the keyboard stays up when changing the edited view.