### PR TITLE
Avoid sending show event for keyboard hide

### DIFF
--- a/Source/SHPKeyboardAwarenessObserver.m
+++ b/Source/SHPKeyboardAwarenessObserver.m
@@ -253,7 +253,7 @@ CGRect shp_normalizedFrame(CGRect frame, UIWindow *window) {
         }
 
     }
-    else if( eventInfo.conflictView != nil && eventInfo.keyboardInfo != nil && (eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow || _eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow)) {
+    else if( eventInfo.conflictView != nil && eventInfo.keyboardInfo != nil && (eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow || _eventInfo.keyboardInfo.eventType == SHPKeyboardEventTypeShow) && eventInfo.keyboardInfo.eventType != SHPKeyboardEventTypeHide) {
         // Show keyboard
         keyboardEvent = [self showEventWithKeyboardInfo:eventInfo.keyboardInfo conflictingView:eventInfo.conflictView];
     }


### PR DESCRIPTION
If the user choses not to use the softwarekeyboard, the framework will forward a show-event, which is in fact a keyboard hide event. This causes the offset to be calculated wrong.
 